### PR TITLE
Bump the version number.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+source 'https://rubygems.org'

--- a/lib/vagrant-port/version.rb
+++ b/lib/vagrant-port/version.rb
@@ -1,3 +1,3 @@
 module VagrantPort
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
The current version on rubygems is marked as 0.0.2 but still has the incorrect require in vagrant-port.rb.  This means that installing this vagrant plugin makes vagrant very sad.  Installing a locally built version is happy.

I bumped the version number.  Can you do the magic thing to post it to rubygems?
